### PR TITLE
SITE-?? Исправление ошибки, если название кнопки не получено

### DIFF
--- a/main/controller/Order/DeliveryAction.php
+++ b/main/controller/Order/DeliveryAction.php
@@ -375,7 +375,8 @@ class DeliveryAction {
                     'longitude'  => (float)$shopItem['coord_long'],
                     'products'   => isset($productIdsByShop[$shopId]) ? $productIdsByShop[$shopId] : [],
                     'pointImage' => '/images/marker.png',
-                    'buttonName' => $deliveryTypeData['now']['buttonName'],
+                    'buttonName' => isset($deliveryTypeData['now']['buttonName']) ? $deliveryTypeData['now']['buttonName'] :
+                            (isset($deliveryTypeData['standart']['buttonName']) ? $deliveryTypeData['standart']['buttonName'] : ''),
                 ];
             }
             // сортировка магазинов


### PR DESCRIPTION
Без доп. проверок при определённых товарах выдавалась на стр /orders/new «ошибка оформления заказа»
